### PR TITLE
Add Docker containerization with Dockerfile and compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+*.egg-info/
+.eggs/
+.env
+.venv/
+venv/
+.git/
+.gitignore
+Dockerfile*
+node_modules/
+
+# Local data and caches
+uploads/*
+!uploads/*.csv
+*.db
+.timetable.db
+*.sqlite
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+# System deps (minimal). Manylinux wheels should cover numpy/pandas, but keep build tools for safety
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       build-essential \
+       curl \
+       ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install Python dependencies first (leverage layer cache)
+COPY requirements.txt ./
+RUN pip install --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir gunicorn
+
+# Copy application source
+COPY . .
+
+# Create runtime directories
+RUN mkdir -p uploads \
+    && chmod -R 775 uploads
+
+ENV FLASK_ENV=production
+EXPOSE 8000
+
+# Start with gunicorn (2 workers, 1 thread each)
+CMD ["gunicorn", "-w", "2", "-b", "0.0.0.0:8000", "app:app"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.9"
+services:
+  web:
+    build: .
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./uploads:/app/uploads
+    restart: unless-stopped


### PR DESCRIPTION
## Purpose
Based on the conversation, the user was working on setting up their Python application and specifically requested Docker containerization. They were looking for guidance on next steps after creating the Dockerfile, indicating they wanted to containerize their application for easier deployment and distribution.

## Code changes
- **Added Dockerfile**: Creates a Python 3.11-slim based container with production-ready configuration using gunicorn WSGI server
- **Added .dockerignore**: Excludes unnecessary files like Python cache, virtual environments, git files, and local data from the Docker build context
- **Added docker-compose.yml**: Provides simple orchestration for running the containerized application with port mapping and volume mounting for uploads

The Docker setup includes optimized layer caching, minimal system dependencies, and production environment configuration with 2 gunicorn workers exposed on port 8000.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6d89d9d28b6e4cd6afd641a1074bf688/cosmos-studio)

👀 [Preview Link](https://6d89d9d28b6e4cd6afd641a1074bf688-cosmos-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6d89d9d28b6e4cd6afd641a1074bf688</projectId>-->
<!--<branchName>cosmos-studio</branchName>-->